### PR TITLE
Tell the cron task the HOME dir is /tmp

### DIFF
--- a/giternity.py
+++ b/giternity.py
@@ -96,6 +96,7 @@ def configure(git_data_path: str, checkout_path: str = None):
 
         cron = """SHELL=/bin/sh
 PATH=/usr/local/sbin:/usr/local/bin:/sbin:/bin:/usr/sbin:/usr/bin
+HOME=/tmp
 
 # m h dom mon dow user  command
 0 * * * * giternity giternity\n"""


### PR DESCRIPTION
Hello,
Thanks for the handy script. One thing I noticed when reviewing the cron logs was the giternity entries complained:
`(CRON) ERROR chdir failed (/home/giternity): No such file or directory`
I've since learned that this is because cron expects a user with a home dir. Since it doesn't make sense for the giternity user to actually have one, providing an explicit HOME dir var will allow the script to operate smoothly without generating errors.