### PR TITLE
Add support for arbitrary git repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,22 @@ repositories = [
     "sunsistemo",
     "TeMPOraL/nyan-mode",
 ]
+
+# Include arbitrary repositories with this pattern (1 [[repos]] block
+# each):
+#
+#    [[repos]]
+#    name = "repo-name"
+#    owner = "owner"
+#    description = "description"
+#    homepage = "https://example.local"
+#    clone_url = "https://git.example.local/owner/repo-name.git"
+[[repos]]
+name = "giternity"
+owner = "rahiel"
+description = "Mirror git repositories and retrieve metadata for cgit "
+homepage = "https://www.rahielkasim.com/mirror-git-repositories-and-serve-them-with-cgit/"
+clone_url = "https://github.com/rahiel/giternity.git"
 ```
 
 Set `git_data_path` to the path where you want to store the git repositories. It

--- a/giternity.py
+++ b/giternity.py
@@ -69,6 +69,20 @@ def main():
                     mirror(repo["clone_url"], path)
                     with open(path + "cgitrc", "w") as f:
                         f.write(gh.repo_to_cgitrc(repo))
+    else:
+        gh = Github(cgit_url=cgit_url)
+
+    # Arbitrary git repositories
+    arbitrary_repos = config.get("repos")
+    if arbitrary_repos:
+        for repo in arbitrary_repos:
+            repo['full_name'] = '{}/{}'.format(repo['owner'], repo['name'])
+            path = "{}{}.git/".format(git_data_path, repo['full_name'])
+            url = repo["clone_url"]
+            metadata = gh.repo_to_cgitrc(repo)
+            mirror(repo["clone_url"], path)
+            with open(path + "cgitrc", "w") as f:
+                f.write(metadata)
 
     def find_repos(path: str):
         for entry in os.scandir(path):


### PR DESCRIPTION
This patch adds support for arbitrary repositories hosted with sites
other than GitHub. Each must be defined in its own [[repos]] block in
the configuration TOML file.

This is a backport of https://github.com/arrdem/giternity/pull/1

closes https://github.com/rahiel/giternity/issues/2